### PR TITLE
Support for nested changeset error handling.

### DIFF
--- a/lib/formatters/ecto/changeset.ex
+++ b/lib/formatters/ecto/changeset.ex
@@ -1,8 +1,24 @@
 defmodule DeliriumTremex.Formatters.Ecto.Changeset do
+  def format({key, [%{} | _] = errors} = _error) when is_list(errors) do
+    errors = Enum.filter(errors, fn x -> not (x == %{}) end)
+    human_key = humanize(key)
+
+    [
+      message: "#{human_key} errors",
+      key: key,
+      messages: nil,
+      full_messages: nil,
+      index: nil,
+      suberrors:
+        Enum.map(errors, fn err -> format({key, err}) end) |> Enum.map(&convert_list_to_map/1)
+    ]
+  end
+
   def format({key, errors} = _error) when is_list(errors) do
     full_messages =
       build_full_messages(key, errors)
       |> List.wrap()
+
     message = full_messages |> hd()
 
     [
@@ -17,13 +33,14 @@ defmodule DeliriumTremex.Formatters.Ecto.Changeset do
 
   def format({key, errors} = _error) when is_map(errors) do
     human_key = humanize(key)
+
     [
       message: "#{human_key} errors",
       key: key,
       messages: nil,
       full_messages: nil,
       index: nil,
-      suberrors: Enum.map(errors, &format/1)
+      suberrors: Enum.map(errors, &format/1) |> Enum.map(&convert_list_to_map/1)
     ]
   end
 
@@ -42,6 +59,7 @@ defmodule DeliriumTremex.Formatters.Ecto.Changeset do
 
   defp build_full_messages(key, errors) do
     human_key = humanize(key)
+
     Enum.map(
       errors,
       fn {value, context} ->
@@ -52,5 +70,10 @@ defmodule DeliriumTremex.Formatters.Ecto.Changeset do
 
   defp translate_error({msg, opts}) do
     Gettext.dgettext(DeliriumTremex.Gettext, "errors", msg, opts)
+  end
+
+  defp convert_list_to_map(keyword_list) do
+    keyword_list
+    |> Enum.into(%{})
   end
 end

--- a/lib/formatters/ecto/changeset.ex
+++ b/lib/formatters/ecto/changeset.ex
@@ -72,7 +72,6 @@ defmodule DeliriumTremex.Formatters.Ecto.Changeset do
   end
 
   defp remove_empty_maps(list_of_maps) do
-    list_of_maps
-    |> Enum.filter(fn x -> not (x == %{}) end)
+    Enum.filter(list_of_maps, fn x -> not (x == %{}) end)
   end
 end

--- a/lib/formatters/ecto/changeset.ex
+++ b/lib/formatters/ecto/changeset.ex
@@ -72,6 +72,6 @@ defmodule DeliriumTremex.Formatters.Ecto.Changeset do
   end
 
   defp remove_empty_maps(list_of_maps) do
-    Enum.filter(list_of_maps, fn x -> not (x == %{}) end)
+    Enum.filter(list_of_maps, fn x -> map_size(x) > 0 end)
   end
 end

--- a/lib/formatters/ecto/changeset.ex
+++ b/lib/formatters/ecto/changeset.ex
@@ -1,6 +1,6 @@
 defmodule DeliriumTremex.Formatters.Ecto.Changeset do
   def format({key, [%{} | _] = errors} = _error) when is_list(errors) do
-    errors = Enum.filter(errors, fn x -> not (x == %{}) end)
+    errors = remove_empty_maps(errors)
     human_key = humanize(key)
 
     [
@@ -9,8 +9,7 @@ defmodule DeliriumTremex.Formatters.Ecto.Changeset do
       messages: nil,
       full_messages: nil,
       index: nil,
-      suberrors:
-        Enum.map(errors, fn err -> format({key, err}) end) |> Enum.map(&convert_list_to_map/1)
+      suberrors: Enum.map(errors, fn err -> format({key, err}) |> Enum.into(%{}) end)
     ]
   end
 
@@ -40,7 +39,7 @@ defmodule DeliriumTremex.Formatters.Ecto.Changeset do
       messages: nil,
       full_messages: nil,
       index: nil,
-      suberrors: Enum.map(errors, &format/1) |> Enum.map(&convert_list_to_map/1)
+      suberrors: Enum.map(errors, fn err -> format(err) |> Enum.into(%{}) end)
     ]
   end
 
@@ -72,8 +71,8 @@ defmodule DeliriumTremex.Formatters.Ecto.Changeset do
     Gettext.dgettext(DeliriumTremex.Gettext, "errors", msg, opts)
   end
 
-  defp convert_list_to_map(keyword_list) do
-    keyword_list
-    |> Enum.into(%{})
+  defp remove_empty_maps(list_of_maps) do
+    list_of_maps
+    |> Enum.filter(fn x -> not (x == %{}) end)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule DeliriumTremex.Mixfile do
   def project do
     [
       app: :delirium_tremex,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,
       elixirc_paths: elixirc_paths(Mix.env),

--- a/test/formatters/ecto/changeset_test.exs
+++ b/test/formatters/ecto/changeset_test.exs
@@ -1,0 +1,62 @@
+defmodule DeliriumTremex.Formatters.Ecto.ChangesetTest do
+  use ExUnit.Case
+  doctest DeliriumTremex
+
+  describe "nested changeset formatting" do
+    test "error nested inside map returns error inside suberrors list" do
+      data = {:foo, %{bar: [{"can't be blank", [validation: :required]}]}}
+
+      formatted_data = DeliriumTremex.Formatters.Ecto.Changeset.format(data)
+
+      assert formatted_data[:suberrors] == [
+               %{
+                 full_messages: ["Bar can't be blank"],
+                 index: nil,
+                 key: :bar,
+                 message: "Bar can't be blank",
+                 messages: ["can't be blank"],
+                 suberrors: nil
+               }
+             ]
+    end
+
+    test "error nested inside list of maps returns error inside nested suberrors list" do
+      data =
+        {:foos,
+         [
+           %{
+             bar_id: [
+               {"does not exist",
+                [
+                  constraint: :foreign,
+                  constraint_name: "foos_bar_id_fkey"
+                ]}
+             ]
+           },
+           %{}
+         ]}
+
+      formatted_data = DeliriumTremex.Formatters.Ecto.Changeset.format(data)
+
+      assert formatted_data[:suberrors] == [
+               %{
+                 full_messages: nil,
+                 index: nil,
+                 key: :foos,
+                 message: "Foos errors",
+                 messages: nil,
+                 suberrors: [
+                   %{
+                     full_messages: ["Bar_id does not exist"],
+                     index: nil,
+                     key: :bar_id,
+                     message: "Bar_id does not exist",
+                     messages: ["does not exist"],
+                     suberrors: nil
+                   }
+                 ]
+               }
+             ]
+    end
+  end
+end

--- a/test/formatters/ecto/changeset_test.exs
+++ b/test/formatters/ecto/changeset_test.exs
@@ -1,19 +1,20 @@
 defmodule DeliriumTremex.Formatters.Ecto.ChangesetTest do
   use ExUnit.Case
   doctest DeliriumTremex
+  alias DeliriumTremex.Formatters.Ecto.Changeset
 
   describe "nested changeset formatting" do
     test "error nested inside map returns error inside suberrors list" do
-      data = {:foo, %{bar: [{"can't be blank", [validation: :required]}]}}
+      data = {:address, %{address_line1: [{"can't be blank", [validation: :required]}]}}
 
-      formatted_data = DeliriumTremex.Formatters.Ecto.Changeset.format(data)
+      formatted_data = Changeset.format(data)
 
       assert formatted_data[:suberrors] == [
                %{
-                 full_messages: ["Bar can't be blank"],
+                 full_messages: ["Address_line1 can't be blank"],
                  index: nil,
-                 key: :bar,
-                 message: "Bar can't be blank",
+                 key: :address_line1,
+                 message: "Address_line1 can't be blank",
                  messages: ["can't be blank"],
                  suberrors: nil
                }
@@ -22,35 +23,35 @@ defmodule DeliriumTremex.Formatters.Ecto.ChangesetTest do
 
     test "error nested inside list of maps returns error inside nested suberrors list" do
       data =
-        {:foos,
+        {:comments,
          [
            %{
-             bar_id: [
+             user_id: [
                {"does not exist",
                 [
                   constraint: :foreign,
-                  constraint_name: "foos_bar_id_fkey"
+                  constraint_name: "comments_user_id_fkey"
                 ]}
              ]
            },
            %{}
          ]}
 
-      formatted_data = DeliriumTremex.Formatters.Ecto.Changeset.format(data)
+      formatted_data = Changeset.format(data)
 
       assert formatted_data[:suberrors] == [
                %{
                  full_messages: nil,
                  index: nil,
-                 key: :foos,
-                 message: "Foos errors",
+                 key: :comments,
+                 message: "Comments errors",
                  messages: nil,
                  suberrors: [
                    %{
-                     full_messages: ["Bar_id does not exist"],
+                     full_messages: ["User_id does not exist"],
                      index: nil,
-                     key: :bar_id,
-                     message: "Bar_id does not exist",
+                     key: :user_id,
+                     message: "User_id does not exist",
                      messages: ["does not exist"],
                      suberrors: nil
                    }


### PR DESCRIPTION
### Changes
- Support for nested changeset error handling. When [first element](https://github.com/VeryBigThings/delirium_tremex/compare/feature/nested_changesets?expand=1#diff-270d50ca02fd2912a62001f187edaecaR2) in errors list is a map, we have encountered nesting.
- Support for [suberrors](https://github.com/VeryBigThings/delirium_tremex/compare/feature/nested_changesets?expand=1#diff-270d50ca02fd2912a62001f187edaecaR43). Previously when suberrors happend, poison would throw Poison.EncodeError because suberrors were a keyword list. 
- Tests for nested changeset. Examples of tests were written according to problems I currently encountered in my application.
