### PR TITLE
Sub-errors of arrays are nested only one level.

### DIFF
--- a/test/formatters/ecto/changeset_test.exs
+++ b/test/formatters/ecto/changeset_test.exs
@@ -39,24 +39,22 @@ defmodule DeliriumTremex.Formatters.Ecto.ChangesetTest do
 
       formatted_data = Changeset.format(data)
 
-      assert formatted_data[:suberrors] == [
-               %{
-                 full_messages: nil,
-                 index: nil,
-                 key: :comments,
-                 message: "Comments errors",
-                 messages: nil,
-                 suberrors: [
-                   %{
-                     full_messages: ["User_id does not exist"],
-                     index: nil,
-                     key: :user_id,
-                     message: "User_id does not exist",
-                     messages: ["does not exist"],
-                     suberrors: nil
-                   }
-                 ]
-               }
+      assert formatted_data == [
+               message: "Comments errors",
+               key: :comments,
+               messages: nil,
+               full_messages: nil,
+               index: nil,
+               suberrors: [
+                 %{
+                   full_messages: ["User_id does not exist"],
+                   index: nil,
+                   key: :user_id,
+                   message: "User_id does not exist",
+                   messages: ["does not exist"],
+                   suberrors: nil
+                 }
+               ]
              ]
     end
   end


### PR DESCRIPTION
In [README](https://github.com/VeryBigThings/delirium_tremex/blob/master/README.mdl) there is an example how nesting should behave:
```JSON
{
  "key": "comments",
  "message": "Error validating all comments",
  "messages": null,
  "fullMessages": null,
  "index": null,
  "subErrors": [
    {
      "key": "content",
      "message": "Content is too short",
      "messages": ["is too short"],
      "fullMessages": ["Content is too short"],
      "index": 1,
      "subErrors": null
    }
  ]
}
```

Change in https://github.com/VeryBigThings/delirium_tremex/pull/5 resulted with subErrors being nested twice when we had an array of maps. 
Example:
```JSON
{
  "key": "comments",
  "message": "Error validating all comments",
  "messages": null,
  "fullMessages": null,
  "index": null,
  "subErrors": [
    {
      "key": "comments",
      "message": "Error validating all comments",
      "messages": null,
      "fullMessages": null,
      "index": null,
      "subErrors": [
        {
          "key": "content",
          "message": "Content is too short",
          "messages": ["is too short"],
          "fullMessages": ["Content is too short"],
          "index": 1,
          "subErrors": null
        }
      ]
    }
    
  ]
}
```

This change makes nesting behave according to README example. 
Tested it also with my project that has several examples of nested arrays, similar to the example in README :)